### PR TITLE
Synchronize tiles across clients

### DIFF
--- a/src/client/play/js/events.js
+++ b/src/client/play/js/events.js
@@ -216,10 +216,12 @@ export default {
 
             // Set tile at origin
             const origin = tile.getOrigin(cell.x, cell.y, o);
+            const transform = ui.getAttribute(`tile-${tile.id}`, 'transform');
             tile.set(origin.x, origin.y);
             socket.emit('tile', {
                 x: origin.x,
                 y: origin.y,
+                transform: transform,
                 tile: tile
             });
 

--- a/src/client/play/js/sockets.js
+++ b/src/client/play/js/sockets.js
@@ -80,6 +80,8 @@ export default {
             const tile = tiles.getTile(data.tile.id);
             tile.rotation = data.tile.rotation;
             tile.set(data.x, data.y);
+            tile.createSVG();
+            ui.setAttribute(`tile-${tile.id}`, 'transform', data.transform);
         });
 
         socket.on('getStatus', user => {

--- a/src/client/play/js/tile.js
+++ b/src/client/play/js/tile.js
@@ -318,6 +318,10 @@ export default class Tile {
         }
     }
 
+    /**
+     * Creates the corresponding <image/> element for this tile and
+     * adds it to the list of tiles.
+     */
     createSVG() {
         // this.move(0, 0);
 


### PR DESCRIPTION
Tiles were not being synchronized because their `<image/>` elements were not being appended to the DOM.

This fixes #26.