### PR TITLE
Use e.code instead of e.which to support other keyboard layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,20 @@ Online version of board game "Magic Maze"
 
 ### Keyboard commands
 
-| Key | Command |
-| --- | --- |
-| C | Activate explore (double click on the tile to place) |
-| T | Rotate new tile clockwise (or use Right Mouse click) |
-| R | Rotate new tile counter clockwise |
-| Esc | Cancel current action |
-| P | Pause game |
-| G | Toggle grid |
-| S | Move map up |
-| Z | Move map down |
-| D | Move map left |
-| Q | Move map right |
-| E | Zoom map in |
-| A | Zoom map out |
+| Command | AZERTY | QWERTY | 
+| --- | --- | --- | 
+| Activate explore (double click on the tile to place) | C | C |
+| Rotate new tile clockwise (or use Right Mouse click) | T | T |
+| Rotate new tile counter clockwise | R | R |
+| Cancel current action | Esc | Esc |
+| Pause game | Spacebar | Spacebar |
+| Toggle grid | G | G |
+| Move map up | S | W |
+| Move map down | Z | S |
+| Move map left | D | A |
+| Move map right | Q | D |
+| Zoom map in | E | E |
+| Zoom map out | A | Q |
 
 ## Development
 

--- a/src/client/play/js/camera.js
+++ b/src/client/play/js/camera.js
@@ -24,9 +24,9 @@ export default {
     * Animate camera zoom
     */
     zoom() {
-        if (events.isKeyDown(65)) { // A: zoom out
+        if (events.isZoomingOut()) {
             this.targetZoom -= .1;
-        } else if (events.isKeyDown(69)) { // E: zoom in
+        } else if (events.isZoomingIn()) {
             this.targetZoom += .1;
         }
 
@@ -49,16 +49,16 @@ export default {
     * Move camera around
     */
     move() {
-        if (events.isKeyDown(90)) { // Z: move up
+        if (events.isMovingUp()) {
             this.y -= config.cameraSpeed / this.zoomValue * 2;
         }
-        if (events.isKeyDown(81)) { // Q: move left
+        if (events.isMovingLeft()) {
             this.x -= config.cameraSpeed / this.zoomValue * 2;
         }
-        if (events.isKeyDown(83)) { // S: move down
+        if (events.isMovingDown()) {
             this.y += config.cameraSpeed / this.zoomValue * 2;
         }
-        if (events.isKeyDown(68)) { // D: move right
+        if (events.isMovingRight()) {
             this.x += config.cameraSpeed / this.zoomValue * 2;
         }
 

--- a/src/client/play/js/events.js
+++ b/src/client/play/js/events.js
@@ -23,7 +23,7 @@ const KEY_ZOOM_IN = "KeyE";
 const KEY_EXPLORE = "KeyC";
 const KEY_ROTATE_TILE_CLOCKWISE = "KeyR";
 const KEY_ROTATE_TILE_COUNTER_CLOCKWISE = "KeyT";
-const KEY_CANCEP = "Escape";
+const KEY_CANCEL = "Escape";
 const KEY_PAUSE = "Space";
 const KEY_TOGGLE_GRID = "KeyG";
 
@@ -49,7 +49,7 @@ export default {
                 if (!game.isEnded()) this.rotateTile(-1);
             } else if (e.code === KEY_ROTATE_TILE_COUNTER_CLOCKWISE) { // rotate tile clockwise
                 if (!game.isEnded()) this.rotateTile(1);
-            } else if (e.code === KEY_CANCEP) { // cancel current action
+            } else if (e.code === KEY_CANCEL) { // cancel current action
                 if (!game.isEnded()) this.cancel();
             } else if (e.code === 66) { // B
                 // Steal
@@ -151,6 +151,7 @@ export default {
         if (cell && !(cell.x === hero.cell.x && cell.y === hero.cell.y)) {
             if (this.action === 'hero' && hero.canGoTo(cell)) {
                 hero.set(cell.x, cell.y);
+                this.checkForEvents(cell, hero);
                 socket.emit('hero', {
                     id: hero.id,
                     cell: cell
@@ -202,6 +203,10 @@ export default {
         };
 
         const el = document.elementFromPoint(this.mouse.x, this.mouse.y);
+        if (el === undefined || el === null) {
+            console.log(el);
+            debugger;
+        }
         if (el.nodeName === 'rect') this.hoveredTile.bcr = el.getBoundingClientRect();
         else this.hoveredTile.bcr = null;
 

--- a/src/client/play/js/events.js
+++ b/src/client/play/js/events.js
@@ -39,7 +39,7 @@ export default {
         /**
          * General key press actions
          * @param {Object} e event
-        */
+         */
         document.addEventListener('keydown', e => {
             if (!this.keysDown.includes(e.code)) this.keysDown.push(e.code);
 

--- a/src/client/play/js/events.js
+++ b/src/client/play/js/events.js
@@ -12,6 +12,21 @@ import Tile from './tile';
 import tiles from './tiles';
 import ui from './ui';
 
+const KEY_UP = "KeyW";
+const KEY_DOWN = "KeyS";
+const KEY_LEFT = "KeyA";
+const KEY_RIGHT = "KeyD";
+
+const KEY_ZOOM_OUT = "KeyQ";
+const KEY_ZOOM_IN = "KeyE";
+
+const KEY_EXPLORE = "KeyC";
+const KEY_ROTATE_TILE_CLOCKWISE = "KeyR";
+const KEY_ROTATE_TILE_COUNTER_CLOCKWISE = "KeyT";
+const KEY_CANCEP = "Escape";
+const KEY_PAUSE = "Space";
+const KEY_TOGGLE_GRID = "KeyG";
+
 export default {
     action: '', // '', 'placing', 'hero'
     crystal: null,
@@ -24,31 +39,31 @@ export default {
         /**
          * General key press actions
          * @param {Object} e event
-         */
+        */
         document.addEventListener('keydown', e => {
-            if (!this.keysDown.includes(e.which)) this.keysDown.push(e.which);
+            if (!this.keysDown.includes(e.code)) this.keysDown.push(e.code);
 
-            if (e.which === 67) { // C: engage tile placing
+            if (e.code === KEY_EXPLORE) { // tile placing
                 if (!game.isEnded()) this.newTile();
-            } else if (e.which === 82) { // R: rotate tile counterclockwise
+            } else if (e.code === KEY_ROTATE_TILE_CLOCKWISE) { // rotate tile counterclockwise
                 if (!game.isEnded()) this.rotateTile(-1);
-            } else if (e.which === 84) { // T: rotate tile clockwise
+            } else if (e.code === KEY_ROTATE_TILE_COUNTER_CLOCKWISE) { // rotate tile clockwise
                 if (!game.isEnded()) this.rotateTile(1);
-            } else if (e.which === 27) { // Esc: cancel current action
+            } else if (e.code === KEY_CANCEP) { // cancel current action
                 if (!game.isEnded()) this.cancel();
-            } else if (e.which === 66) { // B
+            } else if (e.code === 66) { // B
                 // Steal
                 // game.setPhase(2);
-            } else if (e.which === 80) { // P
+            } else if (e.code === KEY_PAUSE) { // pause the game
                 if (game.isPaused()) game.resume();
                 else game.pause();
-            } else if (e.which === 71) { // G
+            } else if (e.code === KEY_TOGGLE_GRID) { // toggle grid visibility
                 ui.toggleClass('grid', 'visible');
             }
         });
 
         document.addEventListener('keyup', e => {
-            this.keysDown.splice(this.keysDown.indexOf(e.which), 1);
+            this.keysDown.splice(this.keysDown.indexOf(e.code), 1);
         });
 
         document.getElementById('game-wrap').addEventListener('mousedown', () => {
@@ -83,6 +98,30 @@ export default {
             if (!game.isEnded()) this.rotateTile(1);
             return false;
         }
+    },
+
+    isMovingUp() {
+        return this.isKeyDown(KEY_UP);
+    },
+
+    isMovingDown() {
+        return this.isKeyDown(KEY_DOWN);
+    },
+
+    isMovingLeft() {
+        return this.isKeyDown(KEY_LEFT);
+    },
+
+    isMovingRight() {
+        return this.isKeyDown(KEY_RIGHT);
+    },
+
+    isZoomingOut() {
+        return this.isKeyDown(KEY_ZOOM_OUT);
+    },
+
+    isZoomingIn() {
+        return this.isKeyDown(KEY_ZOOM_IN);
     },
 
     mouseDown() {


### PR DESCRIPTION
The current implementation of the keybinding system uses the deprecated `which` property. This makes the UI not portable across different keyboard layouts. Using [`code`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code) instead will make it the keybindings consistent across different keyboard layouts.

This addresses #36.