### PR TITLE
Restrict actions based on their roles

### DIFF
--- a/src/client/play/js/config.js
+++ b/src/client/play/js/config.js
@@ -1,5 +1,7 @@
 export default {
-    debug: true,
+    // set this to true to allow a player to have all the roles for
+    // testing purposes
+    debug: false,
     grid: true,
     cameraSpeed: 5,
     cameraMouse: false,


### PR DESCRIPTION
Turn off the `debug` flag as it should not be on by default. Also added a comment to the flag so that readers will know what the `debug` flag does.