### PR TITLE
Ignore mouse positions that are outside the game

### DIFF
--- a/src/client/play/js/events.js
+++ b/src/client/play/js/events.js
@@ -211,11 +211,11 @@ export default {
         };
 
         const el = document.elementFromPoint(this.mouse.x, this.mouse.y);
-        if (el === undefined || el === null) {
-            console.log(el);
-            debugger;
-        }
-        if (el.nodeName === 'rect') this.hoveredTile.bcr = el.getBoundingClientRect();
+        // the element may be undefined which implies the mouse is
+        // currently outside of the bounds of the game window, this may
+        // happen when the browser window is being resized, consider
+        // ourselves as not currently hovering over any tile then
+        if (el && el.nodeName === 'rect') this.hoveredTile.bcr = el.getBoundingClientRect();
         else this.hoveredTile.bcr = null;
 
         const cell = this.getHoveredCell();


### PR DESCRIPTION
Depending on how the events are dispatched, the mouse may be recorded as being outside the game if the game window is resized to a smaller size. This means our hovering logic will not return a tile as the mouse is not currently in the game window (and thus not over any tile).

When this happens, ignore such mouse positions and instead only process positions where the mouse is over and inside the game window.

This fix addresses #43.