### PR TITLE
Allow vortex action to be used anywhere

### DIFF
--- a/src/client/play/js/hero.js
+++ b/src/client/play/js/hero.js
@@ -62,14 +62,11 @@ export default class Hero {
 
         // Check for vortex
         if (role.includes('vortex')) {
-            const item = board.get(hero.x, hero.y).item;
-            if (item && item.type === 'vortex' && item.color === this.color) {
-                const targetItem = board.get(target.x, target.y).item;
-                if (targetItem && targetItem.type === 'vortex' && targetItem.color === this.color) {
-                    path.push({x: hero.x, y: hero.y});
-                    path.push({x: target.x, y: target.y, reachable: game.isPhase(1)});
-                    return path;
-                }
+            const targetItem = board.get(target.x, target.y).item;
+            if (targetItem && targetItem.type === 'vortex' && targetItem.color === this.color) {
+                path.push({x: hero.x, y: hero.y});
+                path.push({x: target.x, y: target.y, reachable: game.isPhase(1)});
+                return path;
             }
         }
 


### PR DESCRIPTION
Currently, the vortex action can only be used if the hero is already on a vortex. This ruling is only applicable to scenario 13 and should not be applied to scenarios 1 to 7.

This fixes #45.