### PR TITLE
Always reset mouse state when button is released

### DIFF
--- a/src/client/play/js/events.js
+++ b/src/client/play/js/events.js
@@ -70,7 +70,9 @@ export default {
             if (!game.isEnded()) this.mouseDown();
         });
 
-        document.getElementById('game-wrap').addEventListener('mouseup', () => {
+        // always release all held actions regardless of whether the
+        // mouse was released inside or outside the game's bounds
+        document.addEventListener('mouseup', () => {
             if (!game.isEnded()) this.mouseUp();
         });
 
@@ -179,8 +181,14 @@ export default {
         this.hero = false;
     },
 
+    hasValidHoveredTile() {
+        return this.hoveredTile.bcr !== undefined && this.hoveredTile.bcr !== null &&
+            this.hoveredTile.x !== undefined && this.hoveredTile.x !== null &&
+            this.hoveredTile.y !== undefined && this.hoveredTile.y !== null;
+    },
+
     getHoveredCell() {
-        if (this.hoveredTile.x === null || this.hoveredTile.y === null || !this.hoveredTile.bcr)
+        if (!this.hasValidHoveredTile())
             return null;
 
         let { x, y, bcr } = this.hoveredTile;


### PR DESCRIPTION
Currently, the game only registers the mouse button being released if it is released within the bounds of the game. This means that the game will think that the mouse button is down even when it is not if the button was released outside the game's bounds.

Instead, the game should always evaluate and update its internal state when the mouse button is released. This should prevent inconsistencies in the game's cached state of the mouse and the actual physical state of the mouse.

This addresses #47.