### PR TITLE
Include link back to GitHub on the main page

### DIFF
--- a/public/home/index.html
+++ b/public/home/index.html
@@ -37,6 +37,12 @@
 
         <div class="hr">❖</div>
 
+        <div class="banner">
+            Contribute to the development of this project on <a href="https://github.com/ashugeo/magic-maze/">GitHub</a>.
+            <br></br>
+            Open feature requests and bug reports <a href="https://github.com/ashugeo/magic-maze/issues">here</a>! Thank you for your feedback.
+        </div>
+
         <div class="row">
             <div class="box new-game">
                 <p><strong>+</strong></p>

--- a/src/client/home/scss/home.scss
+++ b/src/client/home/scss/home.scss
@@ -93,6 +93,21 @@ h1 {
     }
 }
 
+.banner {
+    position: relative;
+    width: 100%;
+    text-align: center;
+    color: $primary-color;
+    font-size: 1.1rem;
+    margin: 2rem 0;
+    user-select: none;
+
+    a {
+        font-weight: bold;
+        color: #000000;
+    }
+}
+
 a {
     color: $primary-color;
     text-decoration: none;


### PR DESCRIPTION
Players that just find the site randomly will not be aware that the project is developed in the open and that their feedback is welcome. Including a link back to GitHub on the main page should help drive more traffic and ideas to the project.

I'm not much of a CSS person but I figured that getting something there that looks half-decent is better than no link at all.