### PR TITLE
Use unique element names to differentiate what the player is doing

### DIFF
--- a/src/client/home/js/main.js
+++ b/src/client/home/js/main.js
@@ -23,7 +23,7 @@ function init() {
                 </p>
 
                 <label for="nickname">Nickname</label>
-                <input type="text" id="nickname" placeholder="Enter a nickname…" required>
+                <input type="text" id="nickname-${room.id}" placeholder="Enter a nickname…" required>
 
                 <button name="play">Play</button>`;
 
@@ -41,7 +41,7 @@ function init() {
 $(document).on('click', 'button[name="play"]', e => {
     e.preventDefault();
     const room = $(e.target).parents('.box').attr('id');
-    const name = $('#nickname').val();
+    const name = $(`#nickname-${room}`).val();
 
     if (!room || !name) return;
 


### PR DESCRIPTION
Multiple input elements were named `nickname` which meant that the input in one field would overwrite the input of another field. Assigning the input elements a unique id for each game room fixes this problem.